### PR TITLE
v3.0.1: FORMULA_BACKEND auto-resolve + docs run/config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,33 @@ curl -X POST http://localhost:8000/ocr/raw \
 {"results": [{"text": "Invoice Total", "confidence": 0.97, "bounding_box": [[42,10],[210,10],[210,38],[42,38]]}]}
 ```
 
+### Start it with the stages you want
+
+All weights are baked into the image — just set the backend env var to load a
+stage (no paths needed). Layout is on by default; each extra stage still only
+runs when the request asks for it.
+
+```bash
+# text + layout (default)
+docker run --gpus all -p 8000:8000 -p 50051:50051 \
+  -v trt-cache:/home/ocr/.cache/turbo-ocr ghcr.io/aiptimizer/turboocr:latest
+
+# + tables (→ HTML)       add  -e TABLE_BACKEND=slanext
+# + formulas (→ LaTeX)    add  -e FORMULA_BACKEND=ppformulanet_s
+# + both                  add  -e TABLE_BACKEND=slanext -e FORMULA_BACKEND=ppformulanet_s
+# bigger / other language add  -e OCR_MODEL=medium   (tiny | small | medium | arabic | eslav | korean | thai | greek)
+```
+
+Then opt in per request (combine freely; `tables`/`formulas` auto-enable layout):
+
+```bash
+curl -X POST "http://localhost:8000/ocr/raw?layout=1&tables=1&formulas=1" \
+  --data-binary @paper.png -H "Content-Type: image/png"
+# PDF:  POST /ocr/pdf   ·   Markdown export: POST /ocr/markdown   ·   gRPC: port 50051
+```
+
+`GET /capabilities` reports which stages a running server has loaded.
+
 → [Docker & deployment](docs/build/docker.md) · [Build from source](docs/build/native.md)
 
 ---

--- a/docs/api/grpc.md
+++ b/docs/api/grpc.md
@@ -29,12 +29,13 @@ service OCRService {
     completes. The `grpc::StatusCode` + message remain primary for
     older clients; `x-error-code` is purely additive.
 
-Known codes (from `proto/ocr.proto:12-17`): `LAYOUT_DISABLED`,
+Known codes (from `proto/ocr.proto:12-18`): `LAYOUT_DISABLED`,
 `INVALID_PARAMETER`, `BASE64_DECODE_FAILED`, `IMAGE_DECODE_FAILED`,
 `DIMENSIONS_TOO_LARGE`, `EMPTY_BATCH`, `MISSING_IMAGE`, `MISSING_PDF`,
 `INVALID_DPI`, `INVALID_DIMENSIONS`, `BODY_SIZE_MISMATCH`,
 `PDF_RENDER_FAILED`, `PDF_NOT_AVAILABLE`, `EMPTY_PDF`, `SERVER_BUSY`,
-`INFERENCE_ERROR`, `NOT_READY`.
+`INFERENCE_ERROR`, `NOT_READY`, `TABLE_BACKEND_DISABLED`,
+`FORMULA_BACKEND_DISABLED`, `STRUCTURED_MODE_NO_STRUCTURE`.
 
 ## Response mode (json_bytes vs. structured)
 
@@ -52,9 +53,10 @@ and only `json_response` is filled.
 !!! warning "`tables`/`formulas` require json_bytes mode"
     The structured `results` field carries text only — the proto has no
     table/formula message. So in `structured` response mode a `tables=1`/
-    `formulas=1` request still runs the stage but the HTML/LaTeX is **not**
-    returned. Read `tables`/`formulas` from `json_response` (the default
-    `json_bytes` mode), exactly like the HTTP API.
+    `formulas=1` request is **rejected** with `UNIMPLEMENTED` +
+    `x-error-code: STRUCTURED_MODE_NO_STRUCTURE` (it is not silently
+    degraded). Use the default `json_bytes` mode and read `tables`/`formulas`
+    from `json_response`, exactly like the HTTP API.
 
 `reading_order` is duplicated as a top-level repeated field for clients
 that don't parse the JSON.

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -5,7 +5,10 @@
     entirely; `POST /ocr/batch` and `POST /ocr/pdf` cover multi-image and PDF
     inputs; `POST /ocr/markdown` (GPU build) exports a parsed page as
     Markdown. `GET /health/live` and `GET /health/ready` are
-    Kubernetes-friendly probes. Default bind: `http://localhost:8000`.
+    Kubernetes-friendly probes. The Docker image is fronted by nginx on
+    `http://localhost:8000`; a native build binds port **8080** directly
+    (`PORT`, default 8080). The examples below use `:8000` (the Docker port) —
+    use `:8080` for a native server.
 
 Routes are registered in these files:
 
@@ -28,7 +31,6 @@ Parsed by `server::parse_query_options()` in
 | `as_blocks` | `0` | Emit paragraph-level `blocks`. Auto-enables `layout` + `reading_order`. |
 | `tables` | `0` | Run the table branch (SLANeXt, or a VLM backend) and emit `tables`. Strict opt-in: `1` requires a table backend configured at startup, else `400 TABLE_BACKEND_DISABLED`. Auto-enables `layout`. |
 | `formulas` | `0` | Run the formula branch (PP-FormulaNet-S, in-process ORT-CUDA-13) and emit `formulas`. Strict opt-in: `1` requires a formula backend configured at startup, else `400 FORMULA_BACKEND_DISABLED`. Auto-enables `layout`. |
-| `rec_mode` | env `OCR_REC_MODE` | Per-request recognizer override (`mobile` / `server`). |
 
 !!! note "Optional fields stay byte-identical when empty"
     `layout`, `reading_order`, `blocks`, `tables`, `formulas` are
@@ -183,10 +185,9 @@ point.
     img = cv2.imread("frame.png")  # BGR uint8
     h, w, c = img.shape
     r = requests.post(
-        "http://localhost:8000/ocr/pixels",
+        f"http://localhost:8000/ocr/pixels?width={w}&height={h}&channels={c}",
         data=img.tobytes(),
-        headers={"X-Width": str(w), "X-Height": str(h), "X-Channels": str(c),
-                 "Content-Type": "application/octet-stream"},
+        headers={"Content-Type": "application/octet-stream"},
     )
     ```
 
@@ -194,12 +195,9 @@ point.
 
     ```javascript
     // bgr = Uint8Array length = w*h*3
-    await fetch("http://localhost:8000/ocr/pixels", {
+    await fetch(`http://localhost:8000/ocr/pixels?width=${w}&height=${h}&channels=3`, {
       method: "POST",
-      headers: {
-        "X-Width": String(w), "X-Height": String(h), "X-Channels": "3",
-        "Content-Type": "application/octet-stream",
-      },
+      headers: { "Content-Type": "application/octet-stream" },
       body: bgr,
     });
     ```
@@ -477,6 +475,28 @@ curl http://localhost:8000/health/ready
     engine-build time as a hard failure
     (`docker/nginx.conf.template:36-47`).
 
+## `GET /capabilities`
+
+Reports what the running server actually loaded — use it to check whether
+`tables`/`formulas` will work before sending `?tables=1`/`?formulas=1` (those
+return `400 *_BACKEND_DISABLED` when the backend isn't loaded).
+
+```bash
+curl http://localhost:8000/capabilities
+```
+
+```json
+{
+  "is_gpu": true,
+  "features": { "layout": true, "tables": true, "formulas": true, "autorotate": false },
+  "routing": { "routes": { "table": "table-env", "formula": "formula-env", "text": "default" } }
+}
+```
+
+`features.{layout,tables,formulas,autorotate}` reflect the loaded stages (formula
+and table are `true` only when their backend env var was set at startup). The
+`routing` block lists backend **names + kinds only** — never URLs/keys.
+
 ## Error envelope
 
 Every error response carries the shared envelope:
@@ -486,7 +506,7 @@ Every error response carries the shared envelope:
            "message": "Image dimensions 32000x32000 exceed maximum of 16384x16384"}}
 ```
 
-Codes are documented inline in `proto/ocr.proto:12-17` and are the same
+Codes are documented inline in `proto/ocr.proto:12-18` and are the same
 strings the gRPC server surfaces in the `x-error-code` trailing metadata
 field.
 

--- a/docs/api/monitoring.md
+++ b/docs/api/monitoring.md
@@ -136,8 +136,8 @@ identifiers regardless of transport (`proto/ocr.proto:5-22`).
 | `BODY_SIZE_MISMATCH` | 400 | `/ocr/pixels` body length != `width × height × channels`. |
 | `EMPTY_BATCH` | 400 | `/ocr/batch` received an empty `images` array. |
 | `LAYOUT_DISABLED` | 400 | A layout-dependent feature requested against a `DISABLE_LAYOUT=1` server. |
-| `TABLE_BACKEND_DISABLED` | 400 | `tables=1` requested but no table backend loaded (`TABLE_BACKEND=` + `TABLE_SLANEXT_ENCODER_ONNX=`). |
-| `FORMULA_BACKEND_DISABLED` | 400 | `formulas=1` requested but no formula backend loaded (`FORMULA_ONNX=` + `FORMULA_TOKENIZER=`). |
+| `TABLE_BACKEND_DISABLED` | 400 | `tables=1` requested but no table backend loaded — start with `TABLE_BACKEND=slanext` (weights auto-resolve). |
+| `FORMULA_BACKEND_DISABLED` | 400 | `formulas=1` requested but no formula backend loaded — start with `FORMULA_BACKEND=ppformulanet_s` (weights auto-resolve). |
 | `STRUCTURED_MODE_NO_STRUCTURE` | 400/UNIMPLEMENTED | gRPC `tables`/`formulas` requested under `structured` response mode (use `json_bytes`). |
 | `MISSING_FILE` | 400 | Multipart upload missing the `file`/`pdf` field. |
 | `MISSING_PDF` | 400 | PDF payload absent. |

--- a/docs/benchmarks/omnidocbench.md
+++ b/docs/benchmarks/omnidocbench.md
@@ -173,8 +173,11 @@ internal engineering notes for the per-attempt diary.
 ## 6. Reproduce
 
 ```bash
-# 1. Start the OCR server (assumes engines are built and cached)
+# 1. Start the OCR server with table + formula enabled (else ?tables=1&formulas=1
+#    below returns 400 ...BACKEND_DISABLED). Backend vars auto-resolve the baked
+#    weights — no model paths needed.
 LD_LIBRARY_PATH="$HOME/TensorRT-10.15.1.29/lib:$LD_LIBRARY_PATH" \
+  TABLE_BACKEND=slanext FORMULA_BACKEND=ppformulanet_s \
   ./build/turboocr-server --http-port 8000 --log-level warn &
 
 # 2. Render predictions for all 1651 pages (~18 s wall on RTX 5090)

--- a/docs/build/config.md
+++ b/docs/build/config.md
@@ -88,6 +88,27 @@ build the variables are `*_ONNX`; on the CPU build they are `*_MODEL`.
     is on by default — to disable it set `DISABLE_LAYOUT=1`, or simply
     remove the variable.
 
+## Tables & formulas
+
+Both are **opt-in**: a stage loads only when its backend env var is set at
+startup, and runs only when the request passes `?tables=1` / `?formulas=1`.
+Weights are baked into the image, so setting the backend var is enough — the
+model paths auto-resolve to `models/table/...` / `models/formula/<engine>/` and
+the `*_ONNX` overrides below are only needed for a non-default location.
+
+| Variable | Default | Description |
+|---|---|---|
+| `TABLE_BACKEND` | *(unset)* | `slanext` enables SLANet-Plus table → HTML; auto-resolves the baked encoder. (`vlm` routes to a VL endpoint.) |
+| `TABLE_SLANEXT_ENCODER_ONNX` | `models/table/slanext_encoder/SLANeXt_wired_encoder.onnx` | Override the table encoder path; decoder `.bin` + dict are derived next to it. |
+| `FORMULA_BACKEND` | *(unset)* | `ppformulanet_s` (English/Latin, default engine) or `ppformulanet_plus_m` (Chinese-capable, GPU only) enables formula → LaTeX; auto-resolves the baked weights. |
+| `FORMULA_ONNX` | `models/formula/<engine>` | Override the formula model dir/file. Only needed for a non-baked location. |
+| `FORMULA_TOKENIZER` | `models/formula/<engine>/tokenizer.json` | Override the formula tokenizer path. |
+
+!!! note "CPU build"
+    On the CPU build, `FORMULA_BACKEND` selects only `ppformulanet_s` (plus-M is
+    GPU only). `TABLE_BACKEND=slanext` / `FORMULA_BACKEND=ppformulanet_s` both
+    auto-resolve the same baked paths as the GPU build.
+
 ## PDF
 
 | Variable | Default | Description |

--- a/docs/build/docker.md
+++ b/docs/build/docker.md
@@ -86,7 +86,11 @@ nginx, then execs the CMD.
 
 | Arg | Default | Effect |
 |---|---|---|
-| `OCR_INCLUDE_SERVER` | `1` | Bake the larger `chinese-server` recognition bundle into the image. Set to `0` to skip it. |
+| `TARGETARCH` | host arch | Set automatically by `docker buildx` (`amd64` / `arm64`); selects the matching ONNX Runtime + PDFium binaries. |
+| `ORT_VERSION` | `1.22.0` | ONNX Runtime C++ SDK version baked in. |
+
+All model weights (every tier + language + table/formula) are fetched from the
+GitHub Release at build time, so there is no language-bundle build arg.
 
 ## CPU image
 
@@ -112,7 +116,9 @@ These are read by the server itself and apply to both Dockerfiles:
 | `DISABLE_LAYOUT` | unset | Skip loading PP-DocLayoutV3 (smaller startup, no `?layout=1`). |
 | `MAX_IMAGE_DIM` | `16384` | Pre/post-decode dimension cap (clamped `[64, 65535]`). |
 | `MAX_PDF_PAGES` | `2000` | Hard cap on `/ocr/pdf` page count. |
-| `OCR_REC_MODE` | `mobile` | Default recognizer (`mobile` / `server`). |
+| `OCR_MODEL` | `tiny` | Recognizer tier / language: `tiny`/`small`/`medium` (Latin+Chinese+Japanese) or `arabic`/`eslav`/`korean`/`thai`/`greek`. |
+| `TABLE_BACKEND` | unset | `slanext` enables table→HTML (baked encoder auto-resolves). Run per request with `?tables=1`. |
+| `FORMULA_BACKEND` | unset | `ppformulanet_s` enables formula→LaTeX (baked weights auto-resolve); `ppformulanet_plus_m` for Chinese (GPU). Run per request with `?formulas=1`. |
 | `MAX_BODY_MB` | `100` | nginx `client_max_body_size` (consumed by the nginx template). |
 | `MODELS_RELEASE_URL` | release URL | Override the models bundle base URL at build time. |
 

--- a/docs/build/models.md
+++ b/docs/build/models.md
@@ -10,7 +10,7 @@
 ## Release URL
 
 ```bash
-MODELS_RELEASE_URL="${MODELS_RELEASE_URL:-https://github.com/aiptimizer/TurboOCR/releases/download/models-v2.1.0}"
+MODELS_RELEASE_URL="${MODELS_RELEASE_URL:-https://github.com/aiptimizer/TurboOCR/releases/download/models-v3.0.0-ppocrv6}"
 ```
 
 Override `MODELS_RELEASE_URL` to pin a different release tag (e.g.
@@ -20,27 +20,29 @@ inside an air-gapped mirror). The fetcher first downloads
 
 ## Per-language download flow
 
-For every language in `LANGS=(chinese greek eslav arabic korean thai)`
-(plus `chinese-server` when `OCR_INCLUDE_SERVER=1`):
+The PP-OCRv6 tiers cover Latin + Chinese + Japanese, so Chinese is **not** a
+separate download. Only the non-Latin scripts have per-language recognizers —
+for every script in `LANGS=(greek eslav arabic korean thai)`:
 
 ```text
 ${MODELS_RELEASE_URL}/rec-${lang}.onnx   →  models/rec/${lang}/rec.onnx
 ${MODELS_RELEASE_URL}/dict-${lang}.txt   →  models/rec/${lang}/dict.txt
 ```
 
-!!! note "chinese-server reuses chinese's dict"
-    `chinese-server` is a bigger PP-OCRv5 backbone trained on the same
-    label set, so the fetcher copies `chinese/dict.txt` rather than
-    pulling a duplicate (`fetch_release_models.sh:67-70`).
-
-The shared / Latin-default heads land at:
+The default PP-OCRv6 det/rec/cls tiers + shared stages land at:
 
 ```text
-${MODELS_RELEASE_URL}/det.onnx       →  models/det.onnx
-${MODELS_RELEASE_URL}/cls.onnx       →  models/cls.onnx
-${MODELS_RELEASE_URL}/rec.onnx       →  models/rec.onnx       (Latin)
-${MODELS_RELEASE_URL}/keys.txt       →  models/keys.txt       (Latin)
-${MODELS_RELEASE_URL}/layout.onnx    →  models/layout/layout.onnx
+${MODELS_RELEASE_URL}/det.onnx        →  models/det.onnx        (PP-OCRv6 medium det)
+${MODELS_RELEASE_URL}/det_small.onnx  →  models/det_small.onnx
+${MODELS_RELEASE_URL}/det_tiny.onnx   →  models/det_tiny.onnx   (default tier)
+${MODELS_RELEASE_URL}/rec.onnx        →  models/rec.onnx        (PP-OCRv6 medium, Latin+CJK)
+${MODELS_RELEASE_URL}/rec_small.onnx  →  models/rec_small.onnx
+${MODELS_RELEASE_URL}/rec_tiny.onnx   →  models/rec_tiny.onnx   (default tier)
+${MODELS_RELEASE_URL}/keys.txt        →  models/keys.txt
+${MODELS_RELEASE_URL}/keys_tiny.txt   →  models/keys_tiny.txt
+${MODELS_RELEASE_URL}/cls.onnx        →  models/cls.onnx
+${MODELS_RELEASE_URL}/layout.onnx     →  models/layout/layout.onnx
+${MODELS_RELEASE_URL}/doc_ori.onnx    →  models/doc_ori.onnx
 ```
 
 ## On-disk inventory
@@ -49,13 +51,13 @@ Verified tree from this checkout (`find models -maxdepth 3 -type f`):
 
 ```text
 cls.onnx
-det.onnx
-keys.txt
+det.onnx              det_small.onnx   det_tiny.onnx     # PP-OCRv6 det tiers
+rec.onnx             rec_small.onnx   rec_tiny.onnx      # PP-OCRv6 rec tiers (Latin+CJK)
+keys.txt             keys_tiny.txt
+doc_ori.onnx
 MANIFEST.txt
-rec.onnx
 layout/layout.onnx
 rec/arabic/{rec.onnx,dict.txt}
-rec/chinese/{rec.onnx,dict.txt}
 rec/eslav/{rec.onnx,dict.txt}
 rec/greek/{rec.onnx,dict.txt}
 rec/korean/{rec.onnx,dict.txt}
@@ -132,5 +134,5 @@ asset that drifts from the pinned hashes.
       hand.
     - [Build → Docker](docker.md) — how the fetcher is staged into the
       image.
-    - [Models → Formula](../models/formula.md) — the three-engine
-      flow that replaces PP-FormulaNet-S.
+    - [Models → Formula](../models/formula.md) — PP-FormulaNet-S, the live
+      backend (the archival three-engine export is documented there too).

--- a/docs/build/native.md
+++ b/docs/build/native.md
@@ -95,9 +95,9 @@ clean build.
 
 ```bash
 export LD_LIBRARY_PATH=/usr/local/tensorrt/lib:$LD_LIBRARY_PATH
-./build/turboocr-server &
-curl -fsS http://localhost:8000/health/ready
-curl -X POST http://localhost:8000/ocr/raw \
+./build/turboocr-server &      # native build binds port 8080 (the 8000→8080 nginx hop is Docker-only)
+curl -fsS http://localhost:8080/health/ready
+curl -X POST http://localhost:8080/ocr/raw \
      --data-binary @tests/test_data/png/receipt.png \
      -H 'Content-Type: image/png'
 ```
@@ -106,7 +106,8 @@ curl -X POST http://localhost:8000/ocr/raw \
     First start spends ~90 s building TensorRT engines from the bundled
     ONNX files; engines are cached under `~/.cache/turbo-ocr/` so
     subsequent runs are instant. `/health/ready` returns `503 NOT_READY`
-    during the build — the curl above will block until it returns 200.
+    during the build — the `curl -fsS` above fails fast on that 503, so retry
+    it (or poll in a loop) until it returns 200.
 
 ## Build output
 

--- a/docs/deployment_vl_separate_gpu.md
+++ b/docs/deployment_vl_separate_gpu.md
@@ -78,7 +78,7 @@ LD_LIBRARY_PATH=/path/to/TensorRT/lib \
 
 Verify the wiring (no secrets are emitted — names + kinds only):
 ```bash
-curl -s http://127.0.0.1:18080/capabilities | jq .routing
+curl -s http://127.0.0.1:8080/capabilities | jq .routing
 # { "routes": {"table":"vl_table","formula":"vl_formula","text":"default"},
 #   "backends": {"vl_table":{"kind":"openai"}, "vl_formula":{"kind":"openai"},
 #                "slanext_local":{"kind":"local"}} }

--- a/docs/models/formula.md
+++ b/docs/models/formula.md
@@ -29,16 +29,17 @@ a degraded stage never looks identical to a page that genuinely had no formula.
 
 | Env | Meaning |
 | --- | --- |
-| `FORMULA_BACKEND=ppformulanet_s` | Select the local PP-FormulaNet-S backend |
-| `FORMULA_ONNX=…/ppformulanet_s/` | Model root; the GPU loads its `fast/` split graphs |
-| `FORMULA_TOKENIZER=…/ppformulanet_s/tokenizer.json` | BPE vocabulary + merges |
+| `FORMULA_BACKEND=ppformulanet_s` | Select the local PP-FormulaNet-S backend. **This is all you need** — the baked weights at `models/formula/ppformulanet_s/` auto-resolve. |
+| `FORMULA_ONNX=…/ppformulanet_s/` | **Override only** — point at a non-baked model root (the GPU loads its `fast/` split graphs from it). Not needed with the baked image. |
+| `FORMULA_TOKENIZER=…/ppformulanet_s/tokenizer.json` | **Override only** — non-baked tokenizer path. |
 | `PPFNS_CHUNK` | Decode batch size (default 8; clamped to [1, 32]) |
 | `PPFNS_DROP_COLLAPSE=1` | Drop mode-collapsed runaway decodes to empty (opt-in; measured worse overall) |
 
 ### Swapping the local model: `-S` (fast) ⇄ `plus-M` (Chinese)
 
-Two local in-process C++ formula models are selectable via `FORMULA_BACKEND` — pick
-one and point `FORMULA_ONNX`/`FORMULA_TOKENIZER` at its files:
+Two local in-process C++ formula models are selectable via `FORMULA_BACKEND`
+(weights auto-resolve from `models/formula/<engine>/`; the `FORMULA_ONNX`/
+`FORMULA_TOKENIZER` overrides below are optional, for non-baked locations):
 
 | `FORMULA_BACKEND` | Model | Chinese (CJK-F1) | English | Speed¹ |
 | --- | --- | --- | --- | --- |
@@ -52,10 +53,8 @@ zero Chinese; `plus-M` recovers ~73% of Chinese characters and edges out `-S` on
 at ~1/12 the throughput.** Use `-S` by default, swap to `plus-M` for Chinese documents.
 
 ```bash
-# Chinese-capable:
-FORMULA_BACKEND=ppformulanet_plus_m \
-FORMULA_ONNX=…/models/formula/ppformulanet_plus_m \
-FORMULA_TOKENIZER=…/models/formula/ppformulanet_plus_m/tokenizer.json
+# Chinese-capable (GPU only) — weights auto-resolve from the baked dir:
+FORMULA_BACKEND=ppformulanet_plus_m
 ```
 
 `plus-M` uses the **same in-process FAST host-loop design** as `-S` (its own

--- a/docs/models/recognition.md
+++ b/docs/models/recognition.md
@@ -39,7 +39,7 @@ while slot N's H2D copy is still in flight
 
 | Field | Value |
 | --- | --- |
-| ONNX path | `models/rec.onnx` (PP-OCRv5 Latin) plus per-script under `models/rec/{arabic,chinese,korean,greek,eslav,thai}/rec.onnx` |
+| ONNX path | `models/rec{,_small,_tiny}.onnx` (PP-OCRv6 medium/small/tiny, Latin+Chinese+Japanese; default tier `tiny`) plus per-script under `models/rec/{arabic,korean,greek,eslav,thai}/rec.onnx` (retained PP-OCRv5) |
 | Engine cache key | `rec_<gpu>_<trt_version>.plan` (one per script) |
 | Input tensor | `x : (N, 3, 48, W)` float32, BGR, ImageNet-normalised |
 | Dynamic profile | MIN `(1,3,48,32)` · OPT `(32,3,48,320)` · MAX `(32,3,48,4000)` |

--- a/docs/resources_speed_accuracy.md
+++ b/docs/resources_speed_accuracy.md
@@ -214,8 +214,8 @@ python3 scripts/bench_speed_matrix.py --n 125 --pool-sizes 2 --concurrency 8
 python3 scripts/bench_speed_matrix.py --baseline result/bench_speed_matrix.json   # regression gate (>15%)
 
 # Accuracy — boot a server with the config, then score (needs omnidocbench/.venv):
-#   local:  TABLE_BACKEND=slanext + SLANEXT envs + FORMULA_BACKEND=ppformulanet_s + FORMULA_ONNX/_TOKENIZER
-#           (in-process ORT-CUDA-13 — no Python sidecar; see the vLLM-free recipe below)
+#   local:  TABLE_BACKEND=slanext + FORMULA_BACKEND=ppformulanet_s  (both auto-resolve
+#           the baked weights; in-process ORT-CUDA-13 — no Python sidecar)
 #   hybrid: TURBO_ROUTING_CONFIG=routing.json (table/formula -> vl), TABLE_SLANEXT_* for slanext_local
 python3 scripts/omnidoc_run_and_score_n.py --server-url http://localhost:8822 --experiment-name local_125
 
@@ -231,14 +231,13 @@ vllm serve models/vlm/paddleocr_vl_1_5 --port 8077 --trust-remote-code \
 ```
 Build recipe (clean): `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DTENSORRT_DIR=<trt> -DFETCH_MODELS=OFF`.
 
-For the local pipeline, enable the formula backend + the reading-order param:
+For the local pipeline, just set the formula backend (weights auto-resolve from
+the baked `models/formula/ppformulanet_s/`):
 ```bash
-FORMULA_BACKEND=ppformulanet_s \
-  FORMULA_ONNX=models/formula/ppformulanet_s/ \
-  FORMULA_TOKENIZER=models/formula/ppformulanet_s/tokenizer.json \
-  ./build/turboocr-server ...
+FORMULA_BACKEND=ppformulanet_s ./build/turboocr-server ...
 # Runs in-process on ORT-CUDA-13 (no Python, no sidecar) from the fast/ split
 # graphs. It fails loud if it can't reach the GPU or the fast/ graphs are
 # missing, and surfaces per-region failures as formula_degraded.
-# Knob: PPFNS_CHUNK (decode batch, default 8).
+# Override the path with FORMULA_ONNX / FORMULA_TOKENIZER only for a non-baked
+# location. Knob: PPFNS_CHUNK (decode batch, default 8).
 ```

--- a/include/turbo_ocr/pipeline/gpu_pipeline_pool.h
+++ b/include/turbo_ocr/pipeline/gpu_pipeline_pool.h
@@ -68,14 +68,29 @@ inline void maybe_load_router_models(OcrPipeline &pipeline) {
     });
     return;
   }
+  // Auto-resolve the baked formula weights when only FORMULA_BACKEND is set
+  // (parity with TABLE_BACKEND=slanext, which defaults its encoder path): use
+  // models/formula/<engine> and let the recognizer find its own files (fast/ for
+  // -S, the dir itself for plus-M). Gated on FORMULA_BACKEND being EXPLICITLY
+  // set, so text-only stays the default; the per-request ?formulas=1 opt-in
+  // still gates execution (loading a backend != running it).
+  std::string formula_onnx = env("FORMULA_ONNX");
+  std::string formula_tok  = env("FORMULA_TOKENIZER");
+  if (const char *fb = std::getenv("FORMULA_BACKEND");
+      fb && *fb && formula_onnx.empty() &&
+      (std::string(fb) == "ppformulanet_s" ||
+       std::string(fb) == "ppformulanet_plus_m")) {
+    formula_onnx = std::string("models/formula/") + fb;
+    if (formula_tok.empty()) formula_tok = formula_onnx + "/tokenizer.json";
+  }
   // Router (CuaRouter) + formula stage. A
   // CONFIGURED backend that fails to load (out-of-memory / bad model) ABORTS
   // boot — we never start a server that silently produces no formulas/tables.
   if (!pipeline.load_router_models(
           env("TABLE_CLS_TRT"), env("TABLE_CELL_WIRED_TRT"),
           env("TABLE_CELL_WIRELESS_TRT"), env("TABLE_SLANEXT_WIRED_TRT"),
-          env("TABLE_SLANEXT_WIRELESS_TRT"), env("FORMULA_ONNX"),
-          env("FORMULA_TOKENIZER")))
+          env("TABLE_SLANEXT_WIRELESS_TRT"), formula_onnx,
+          formula_tok))
     throw turbo_ocr::ModelLoadError(
         "configured formula backend failed to load (out-of-memory or bad model); "
         "refusing to start with formulas silently disabled — lower "

--- a/src/server/cpu_main.cpp
+++ b/src/server/cpu_main.cpp
@@ -156,8 +156,25 @@ int main(int argc, char **argv) try {
   // stage this server didn't load.
   bool table_available = false, formula_available = false;
   {
-    const std::string formula_onnx = turbo_ocr::server::env_or("FORMULA_ONNX", "");
-    const std::string formula_tok = turbo_ocr::server::env_or("FORMULA_TOKENIZER", "");
+    std::string formula_onnx = turbo_ocr::server::env_or("FORMULA_ONNX", "");
+    std::string formula_tok = turbo_ocr::server::env_or("FORMULA_TOKENIZER", "");
+    // Auto-resolve baked formula weights when only FORMULA_BACKEND is set
+    // (parity with the GPU build): default to models/formula/ppformulanet_s
+    // (CPU uses the fused inference_trt.onnx inside it via CpuFormulaRecognizer).
+    if (const char *fb = std::getenv("FORMULA_BACKEND");
+        fb && std::string(fb) == "ppformulanet_s" && formula_onnx.empty()) {
+      formula_onnx = "models/formula/ppformulanet_s";
+      if (formula_tok.empty())
+        formula_tok = "models/formula/ppformulanet_s/tokenizer.json";
+    }
+    // Auto-resolve the baked SLANeXt encoder when only TABLE_BACKEND=slanext is
+    // set; load_table_backend() reads TABLE_SLANEXT_ENCODER_ONNX from the env.
+    if (const char *tb = std::getenv("TABLE_BACKEND");
+        tb && std::string(tb) == "slanext" &&
+        turbo_ocr::server::env_or("TABLE_SLANEXT_ENCODER_ONNX", "").empty()) {
+      setenv("TABLE_SLANEXT_ENCODER_ONNX",
+             "models/table/slanext_encoder/SLANeXt_wired_encoder.onnx", 1);
+    }
     const bool want_formula = !formula_onnx.empty() && !formula_tok.empty();
     const bool want_table = !turbo_ocr::server::env_or("TABLE_SLANEXT_ENCODER_ONNX", "").empty();
     if (want_formula || want_table) {


### PR DESCRIPTION
## Summary
- **FORMULA_BACKEND auto-resolves baked weights** (parity with TABLE_BACKEND=slanext): `FORMULA_BACKEND=ppformulanet_s` alone now enables formula on GPU and CPU; FORMULA_ONNX/FORMULA_TOKENIZER are overrides only. Default-off and per-request `?formulas=1` opt-in preserved.
- **Docs**: copy-paste per-mode run commands in the README; fixed stale env vars (removed dead OCR_REC_MODE/OCR_INCLUDE_SERVER/chinese-server), the v2.1.0→v3.0.0 default models URL, native vs Docker ports, /ocr/pixels query-param examples, gRPC structured-mode reject + known codes, a new /capabilities section, and the PP-OCRv6 tier model inventory.

## Verification
Both builds; `verify_all` 22/22; auto-resolve confirmed (backend var alone → formulas/tables work, default-off, opt-in gated); no-backend → fail-loud 400s; 2 doc-review agents, all findings fixed (zero stale refs).